### PR TITLE
fix the bug when valiation dataset is small

### DIFF
--- a/DAM/utils/evaluation.py
+++ b/DAM/utils/evaluation.py
@@ -28,7 +28,7 @@ def evaluate(file_path):
 	p_at_2_in_10 = 0.0
 	p_at_5_in_10 = 0.0
 
-        length = len(data)/10
+        length = int(len(data)/10)
 
 	for i in xrange(0, length):
 		ind = i * 10


### PR DESCRIPTION
When validation dataset is small, and this length = len(data)/10 will be integers. It caused the error in range() function in line 33.
Converting/flooring the length to an integer will lose some validation samples as a side effect.
For large dataset, this is not an issue.